### PR TITLE
Add Phase 1 Supabase schema, Flutter boilerplate, docs, and export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+exports/*.zip

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,25 @@
+# Phase 1 Foundation (UIUC Sublease)
+
+## Data model overview
+
+- `profiles` extends `auth.users` for dual-tier auth (`student` vs `resident`) and verification state.
+- `listings` belongs to one lessor profile and enforces:
+  - max 3 month lease window (`<= 92` days),
+  - UIUC dorm address blocking,
+  - break-focused categorization.
+- `transactions` is the escrow ledger between one listing, lessor, and sublessee with Stripe IDs.
+- `conversations`, `conversation_participants`, and `messages` model secure in-app chat.
+
+## Relationship summary
+
+- `auth.users (1) -> (1) profiles`
+- `profiles (1) -> (N) listings`
+- `listings (1) -> (N) transactions`
+- `profiles (1) -> (N) transactions` as `lessor_id`
+- `profiles (1) -> (N) transactions` as `sublessee_id`
+- `listings (1) -> (N) conversations`
+- `conversations (1) -> (N) messages`
+- `conversations (1) -> (N) conversation_participants`
+- `profiles (1) -> (N) conversation_participants`
+
+See full SQL in `supabase/phase1_schema.sql`.

--- a/DOWNLOAD_AND_OPEN_IN_VSCODE.md
+++ b/DOWNLOAD_AND_OPEN_IN_VSCODE.md
@@ -1,0 +1,34 @@
+# Download and open this project in VS Code
+
+## Option A (recommended): Download one ZIP with everything
+
+From the repo root, run:
+
+```bash
+bash scripts/export_project_zip.sh
+```
+
+This generates:
+
+- `exports/uiuc_sublease_phase1.zip`
+
+Then download that ZIP and unzip locally.
+
+## Option B: clone directly
+
+If this repo is on GitHub/GitLab, clone it locally and open in VS Code:
+
+```bash
+git clone <repo-url> uiuc-sublease-phase1
+cd uiuc-sublease-phase1
+code .
+```
+
+## Open in VS Code after unzip
+
+```bash
+cd uiuc_sublease_phase1
+code .
+```
+
+If `code` command is missing, open VS Code manually and choose **File -> Open Folder**.

--- a/flutter_boilerplate/lib/main.dart
+++ b/flutter_boilerplate/lib/main.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'screens/auth_gate.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await Supabase.initialize(
+    url: const String.fromEnvironment('SUPABASE_URL'),
+    anonKey: const String.fromEnvironment('SUPABASE_ANON_KEY'),
+  );
+
+  runApp(const ProviderScope(child: UiucSubleaseApp()));
+}
+
+class UiucSubleaseApp extends StatelessWidget {
+  const UiucSubleaseApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'UIUC Sublease',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.orange),
+      home: const AuthGate(),
+    );
+  }
+}

--- a/flutter_boilerplate/lib/models/app_user.dart
+++ b/flutter_boilerplate/lib/models/app_user.dart
@@ -1,0 +1,34 @@
+enum UserType { student, resident }
+
+enum VerificationStatus { pending, verified, rejected }
+
+class AppUser {
+  const AppUser({
+    required this.id,
+    required this.email,
+    required this.userType,
+    required this.verificationStatus,
+  });
+
+  final String id;
+  final String email;
+  final UserType userType;
+  final VerificationStatus verificationStatus;
+
+  bool get isIllinoisEmail => email.toLowerCase().endsWith('@illinois.edu');
+
+  factory AppUser.fromJson(Map<String, dynamic> json) {
+    return AppUser(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      userType: (json['user_type'] as String) == 'student'
+          ? UserType.student
+          : UserType.resident,
+      verificationStatus: switch (json['id_verification_status'] as String) {
+        'verified' => VerificationStatus.verified,
+        'rejected' => VerificationStatus.rejected,
+        _ => VerificationStatus.pending,
+      },
+    );
+  }
+}

--- a/flutter_boilerplate/lib/screens/auth_gate.dart
+++ b/flutter_boilerplate/lib/screens/auth_gate.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/providers.dart';
+import 'auth_screen.dart';
+import 'home_screen.dart';
+
+class AuthGate extends ConsumerWidget {
+  const AuthGate({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authStateProvider);
+
+    return authState.when(
+      data: (state) {
+        if (state.session == null) {
+          return const AuthScreen();
+        }
+        return const HomeScreen();
+      },
+      loading: () => const Scaffold(body: Center(child: CircularProgressIndicator())),
+      error: (error, _) => Scaffold(body: Center(child: Text('Auth error: $error'))),
+    );
+  }
+}

--- a/flutter_boilerplate/lib/screens/auth_screen.dart
+++ b/flutter_boilerplate/lib/screens/auth_screen.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/providers.dart';
+
+class AuthScreen extends ConsumerStatefulWidget {
+  const AuthScreen({super.key});
+
+  @override
+  ConsumerState<AuthScreen> createState() => _AuthScreenState();
+}
+
+class _AuthScreenState extends ConsumerState<AuthScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _nameController = TextEditingController();
+
+  bool _isStudent = true;
+  bool _isLoginMode = false;
+  bool _isLoading = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    setState(() {
+      _error = null;
+      _isLoading = true;
+    });
+
+    final authService = ref.read(authServiceProvider);
+
+    try {
+      if (_isLoginMode) {
+        await authService.signIn(
+          email: _emailController.text,
+          password: _passwordController.text,
+        );
+      } else if (_isStudent) {
+        await authService.signUpStudent(
+          email: _emailController.text,
+          password: _passwordController.text,
+          fullName: _nameController.text,
+        );
+      } else {
+        await authService.signUpResident(
+          email: _emailController.text,
+          password: _passwordController.text,
+          fullName: _nameController.text,
+        );
+
+        final currentUserId = ref.read(supabaseProvider).auth.currentUser?.id;
+        if (currentUserId != null) {
+          await authService.launchIdentityVerification(userId: currentUserId);
+        }
+      }
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('UIUC Sublease Authentication')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          SegmentedButton<bool>(
+            segments: const [
+              ButtonSegment(value: true, label: Text('Student (@illinois.edu)')),
+              ButtonSegment(value: false, label: Text('Local Resident (ID Verify)')),
+            ],
+            selected: {_isStudent},
+            onSelectionChanged: _isLoginMode
+                ? null
+                : (selection) => setState(() => _isStudent = selection.first),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _nameController,
+            enabled: !_isLoginMode,
+            decoration: const InputDecoration(labelText: 'Full Name'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _emailController,
+            keyboardType: TextInputType.emailAddress,
+            decoration: const InputDecoration(labelText: 'Email'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _passwordController,
+            obscureText: true,
+            decoration: const InputDecoration(labelText: 'Password'),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: _isLoading ? null : _submit,
+            child: Text(_isLoginMode ? 'Sign In' : 'Create Account'),
+          ),
+          TextButton(
+            onPressed: _isLoading
+                ? null
+                : () => setState(() {
+                    _isLoginMode = !_isLoginMode;
+                    _error = null;
+                  }),
+            child: Text(
+              _isLoginMode
+                  ? 'Need an account? Register'
+                  : 'Already have an account? Sign in',
+            ),
+          ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          if (!_isLoginMode && !_isStudent)
+            const Padding(
+              padding: EdgeInsets.only(top: 8),
+              child: Text(
+                'Resident accounts remain pending until government ID is verified via Stripe Identity.',
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_boilerplate/lib/screens/home_screen.dart
+++ b/flutter_boilerplate/lib/screens/home_screen.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/providers.dart';
+import '../widgets/break_category_card.dart';
+
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  static const _breaks = [
+    ('Thanksgiving Break', Icons.park_outlined, 'Late Nov • 7-10 days'),
+    ('Winter Break', Icons.ac_unit, 'Dec-Jan • 1-2 months'),
+    ('Spring Break', Icons.flight_takeoff, 'March • 7-10 days'),
+    ('Summer Holiday', Icons.wb_sunny_outlined, 'May-Aug • up to 3 months'),
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileAsync = ref.watch(currentProfileProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Find a Break Sublease'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () => ref.read(authServiceProvider).signOut(),
+          ),
+        ],
+      ),
+      body: profileAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text('Profile error: $error')),
+        data: (profile) {
+          final verificationText = switch (profile?.verificationStatus) {
+            null => 'Unverified',
+            _ => profile!.verificationStatus.name,
+          };
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text(
+                'Verification: $verificationText',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 6),
+              const Text(
+                'Choose a UIUC break period to quickly filter listings.',
+              ),
+              const SizedBox(height: 16),
+              ..._breaks.map(
+                (item) => Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: BreakCategoryCard(
+                    title: item.$1,
+                    subtitle: item.$3,
+                    iconData: item.$2,
+                    onTap: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text('Filter applied: ${item.$1}')),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/flutter_boilerplate/lib/services/auth_service.dart
+++ b/flutter_boilerplate/lib/services/auth_service.dart
@@ -1,0 +1,98 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/app_user.dart';
+
+class AuthService {
+  AuthService(this._supabase);
+
+  final SupabaseClient _supabase;
+
+  Session? get currentSession => _supabase.auth.currentSession;
+
+  Stream<AuthState> get authState => _supabase.auth.onAuthStateChange;
+
+  Future<void> signUpStudent({
+    required String email,
+    required String password,
+    String? fullName,
+  }) async {
+    final normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail.endsWith('@illinois.edu')) {
+      throw const AuthException('Student sign-up requires an @illinois.edu email.');
+    }
+
+    final response = await _supabase.auth.signUp(
+      email: normalizedEmail,
+      password: password,
+      data: {'full_name': fullName ?? ''},
+      emailRedirectTo: null,
+    );
+
+    if (response.user == null) {
+      throw const AuthException('Unable to create student account.');
+    }
+
+    await _supabase.from('profiles').upsert({
+      'id': response.user!.id,
+      'email': normalizedEmail,
+      'full_name': fullName,
+      'user_type': 'student',
+      'id_verification_status': 'verified',
+    });
+  }
+
+  Future<void> signUpResident({
+    required String email,
+    required String password,
+    String? fullName,
+  }) async {
+    final normalizedEmail = email.trim().toLowerCase();
+    final response = await _supabase.auth.signUp(
+      email: normalizedEmail,
+      password: password,
+      data: {'full_name': fullName ?? ''},
+      emailRedirectTo: null,
+    );
+
+    if (response.user == null) {
+      throw const AuthException('Unable to create resident account.');
+    }
+
+    await _supabase.from('profiles').upsert({
+      'id': response.user!.id,
+      'email': normalizedEmail,
+      'full_name': fullName,
+      'user_type': 'resident',
+      'id_verification_status': 'pending',
+    });
+  }
+
+  Future<void> launchIdentityVerification({required String userId}) async {
+    // Placeholder for server-side Stripe Identity session creation.
+    // In production, call Supabase Edge Function that creates Stripe Identity
+    // VerificationSession and returns a redirect URL.
+    await _supabase.from('profiles').update({
+      'stripe_identity_verification_session_id': 'pending_session',
+    }).eq('id', userId);
+  }
+
+  Future<AppUser?> getCurrentProfile() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) return null;
+
+    final payload = await _supabase
+        .from('profiles')
+        .select()
+        .eq('id', userId)
+        .maybeSingle();
+
+    if (payload == null) return null;
+    return AppUser.fromJson(payload);
+  }
+
+  Future<void> signIn({required String email, required String password}) {
+    return _supabase.auth.signInWithPassword(email: email, password: password);
+  }
+
+  Future<void> signOut() => _supabase.auth.signOut();
+}

--- a/flutter_boilerplate/lib/services/providers.dart
+++ b/flutter_boilerplate/lib/services/providers.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/app_user.dart';
+import 'auth_service.dart';
+
+final supabaseProvider = Provider<SupabaseClient>((ref) {
+  return Supabase.instance.client;
+});
+
+final authServiceProvider = Provider<AuthService>((ref) {
+  return AuthService(ref.watch(supabaseProvider));
+});
+
+final authStateProvider = StreamProvider<AuthState>((ref) {
+  return ref.watch(authServiceProvider).authState;
+});
+
+final currentProfileProvider = FutureProvider<AppUser?>((ref) {
+  return ref.watch(authServiceProvider).getCurrentProfile();
+});

--- a/flutter_boilerplate/lib/widgets/break_category_card.dart
+++ b/flutter_boilerplate/lib/widgets/break_category_card.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+class BreakCategoryCard extends StatelessWidget {
+  const BreakCategoryCard({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.iconData,
+    required this.onTap,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData iconData;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Icon(iconData, size: 30),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(title, style: Theme.of(context).textTheme.titleMedium),
+                    const SizedBox(height: 4),
+                    Text(subtitle),
+                  ],
+                ),
+              ),
+              const Icon(Icons.chevron_right),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_boilerplate/pubspec.yaml
+++ b/flutter_boilerplate/pubspec.yaml
@@ -1,0 +1,16 @@
+name: uiuc_sublease_phase1
+description: Phase 1 boilerplate for UIUC subleasing app
+publish_to: none
+version: 0.1.0+1
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  supabase_flutter: ^2.5.6
+  flutter_riverpod: ^2.5.1
+
+flutter:
+  uses-material-design: true

--- a/scripts/export_project_zip.sh
+++ b/scripts/export_project_zip.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPORT_DIR="$ROOT_DIR/exports"
+ZIP_PATH="$EXPORT_DIR/uiuc_sublease_phase1.zip"
+
+mkdir -p "$EXPORT_DIR"
+
+# Build zip from repo root excluding git internals and previous exports.
+(
+  cd "$ROOT_DIR"
+  zip -r "$ZIP_PATH" . \
+    -x ".git/*" \
+    -x "exports/*"
+)
+
+echo "Created: $ZIP_PATH"

--- a/supabase/phase1_schema.sql
+++ b/supabase/phase1_schema.sql
@@ -1,0 +1,245 @@
+-- Phase 1 schema for UIUC hyper-local short-term subleasing app
+-- Intended for Supabase Postgres
+
+create extension if not exists "pgcrypto";
+create extension if not exists "citext";
+
+-- ---------- ENUMS ----------
+create type public.user_type as enum ('student', 'resident');
+create type public.verification_status as enum ('pending', 'verified', 'rejected');
+create type public.break_category as enum (
+  'thanksgiving_break',
+  'winter_break',
+  'spring_break',
+  'summer_holiday',
+  'custom'
+);
+create type public.listing_status as enum ('draft', 'active', 'booked', 'completed', 'cancelled');
+create type public.transaction_status as enum (
+  'initiated',
+  'funds_held',
+  'release_pending',
+  'released',
+  'refunded',
+  'failed'
+);
+
+-- ---------- PROFILES ----------
+create table public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  email citext not null unique,
+  full_name text,
+  phone_number text,
+  user_type public.user_type not null,
+  is_uiuc_student boolean generated always as (email like '%@illinois.edu') stored,
+  id_verification_status public.verification_status not null default 'pending',
+  stripe_customer_id text,
+  stripe_connect_account_id text,
+  stripe_identity_verification_session_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint student_email_guard check (
+    (user_type = 'student' and email like '%@illinois.edu')
+    or user_type = 'resident'
+  )
+);
+
+create index profiles_user_type_idx on public.profiles(user_type);
+create index profiles_verification_idx on public.profiles(id_verification_status);
+
+-- ---------- LISTINGS ----------
+create table public.listings (
+  id uuid primary key default gen_random_uuid(),
+  lessor_id uuid not null references public.profiles(id) on delete cascade,
+  title text not null,
+  description text,
+  address_line_1 text not null,
+  address_line_2 text,
+  city text not null default 'Urbana-Champaign',
+  state text not null default 'IL',
+  postal_code text,
+  latitude numeric(9,6),
+  longitude numeric(9,6),
+  monthly_rent_cents integer not null check (monthly_rent_cents > 0),
+  utility_cap_cents integer not null default 0 check (utility_cap_cents >= 0),
+  roommate_count integer not null default 0 check (roommate_count >= 0),
+  lease_start_date date not null,
+  lease_end_date date not null,
+  break_category public.break_category not null,
+  max_stay_days integer not null generated always as ((lease_end_date - lease_start_date) + 1) stored,
+  status public.listing_status not null default 'draft',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint lease_dates_valid check (lease_end_date >= lease_start_date),
+  constraint lease_max_3_months check ((lease_end_date - lease_start_date) <= 92),
+  constraint block_uiuc_housing check (
+    lower(address_line_1) not similar to '%(far|par|isr|nugent|allen hall|lincoln avenue residence|ike|bousfield|wassaja|larm|lar|taft|weston|snyder)%'
+  )
+);
+
+create index listings_lessor_idx on public.listings(lessor_id);
+create index listings_break_idx on public.listings(break_category);
+create index listings_status_idx on public.listings(status);
+create index listings_dates_idx on public.listings(lease_start_date, lease_end_date);
+
+-- ---------- ESCROW TRANSACTIONS ----------
+create table public.transactions (
+  id uuid primary key default gen_random_uuid(),
+  listing_id uuid not null references public.listings(id) on delete restrict,
+  lessor_id uuid not null references public.profiles(id) on delete restrict,
+  sublessee_id uuid not null references public.profiles(id) on delete restrict,
+  stripe_payment_intent_id text unique,
+  stripe_transfer_id text,
+  stripe_connect_account_id text,
+  total_amount_cents integer not null check (total_amount_cents > 0),
+  escrow_fee_cents integer not null default 0 check (escrow_fee_cents >= 0),
+  platform_fee_cents integer not null default 0 check (platform_fee_cents >= 0),
+  currency text not null default 'usd',
+  status public.transaction_status not null default 'initiated',
+  funds_held_at timestamptz,
+  payout_released_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint lessor_sublessee_must_differ check (lessor_id <> sublessee_id)
+);
+
+create index transactions_listing_idx on public.transactions(listing_id);
+create index transactions_lessor_idx on public.transactions(lessor_id);
+create index transactions_sublessee_idx on public.transactions(sublessee_id);
+create index transactions_status_idx on public.transactions(status);
+
+-- ---------- CONVERSATIONS & MESSAGES ----------
+create table public.conversations (
+  id uuid primary key default gen_random_uuid(),
+  listing_id uuid not null references public.listings(id) on delete cascade,
+  created_by uuid not null references public.profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique(listing_id, created_by)
+);
+
+create table public.conversation_participants (
+  conversation_id uuid not null references public.conversations(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  joined_at timestamptz not null default now(),
+  primary key (conversation_id, user_id)
+);
+
+create table public.messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.conversations(id) on delete cascade,
+  sender_id uuid not null references public.profiles(id) on delete cascade,
+  body text not null,
+  is_read boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index messages_conversation_idx on public.messages(conversation_id, created_at);
+create index participants_user_idx on public.conversation_participants(user_id);
+
+-- ---------- TIMESTAMP TRIGGER ----------
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger profiles_updated_at
+before update on public.profiles
+for each row execute function public.set_updated_at();
+
+create trigger listings_updated_at
+before update on public.listings
+for each row execute function public.set_updated_at();
+
+create trigger transactions_updated_at
+before update on public.transactions
+for each row execute function public.set_updated_at();
+
+-- ---------- RLS ----------
+alter table public.profiles enable row level security;
+alter table public.listings enable row level security;
+alter table public.transactions enable row level security;
+alter table public.conversations enable row level security;
+alter table public.conversation_participants enable row level security;
+alter table public.messages enable row level security;
+
+-- Profiles: users can read verified profiles, update only themselves.
+create policy "profiles_select_verified"
+on public.profiles
+for select
+using (id_verification_status = 'verified' or auth.uid() = id);
+
+create policy "profiles_update_own"
+on public.profiles
+for update
+using (auth.uid() = id)
+with check (auth.uid() = id);
+
+-- Listings: anyone authenticated can read active listings; owners manage their listings.
+create policy "listings_select_active"
+on public.listings
+for select
+using (status = 'active' or auth.uid() = lessor_id);
+
+create policy "listings_insert_own"
+on public.listings
+for insert
+with check (auth.uid() = lessor_id);
+
+create policy "listings_update_own"
+on public.listings
+for update
+using (auth.uid() = lessor_id)
+with check (auth.uid() = lessor_id);
+
+-- Transactions: involved parties only.
+create policy "transactions_select_party"
+on public.transactions
+for select
+using (auth.uid() in (lessor_id, sublessee_id));
+
+create policy "transactions_insert_sublessee"
+on public.transactions
+for insert
+with check (auth.uid() = sublessee_id);
+
+-- Conversations and messages are visible only to participants.
+create policy "conversations_select_participants"
+on public.conversations
+for select
+using (
+  exists (
+    select 1 from public.conversation_participants cp
+    where cp.conversation_id = id and cp.user_id = auth.uid()
+  )
+);
+
+create policy "participants_select_own"
+on public.conversation_participants
+for select
+using (user_id = auth.uid());
+
+create policy "messages_select_participant"
+on public.messages
+for select
+using (
+  exists (
+    select 1 from public.conversation_participants cp
+    where cp.conversation_id = conversation_id and cp.user_id = auth.uid()
+  )
+);
+
+create policy "messages_insert_sender_participant"
+on public.messages
+for insert
+with check (
+  auth.uid() = sender_id and
+  exists (
+    select 1 from public.conversation_participants cp
+    where cp.conversation_id = conversation_id and cp.user_id = auth.uid()
+  )
+);


### PR DESCRIPTION
### Motivation

- Provide a Phase 1 foundation for a UIUC-focused short-term sublease app including database schema, RLS, and enums to enforce domain rules. 
- Ship a minimal Flutter boilerplate wired to Supabase to accelerate UI and auth flows for students and local residents. 
- Add simple contributor docs and an export script to make the project easy to download and open in VS Code. 

### Description

- Added a full Supabase schema at `supabase/phase1_schema.sql` defining enums, `profiles`, `listings`, `transactions`, conversations/messages tables, triggers, indexes, and Row Level Security policies to enforce access rules. 
- Introduced a Flutter app skeleton under `flutter_boilerplate/` including `main.dart`, `pubspec.yaml`, `models/app_user.dart`, `services/auth_service.dart`, `services/providers.dart`, screens (`auth_gate`, `auth_screen`, `home_screen`), and a `BreakCategoryCard` widget wired to basic Supabase auth and profile fetching; `AuthService` contains sign-up/sign-in flows and a placeholder `launchIdentityVerification` for Stripe Identity. 
- Added documentation files `ARCHITECTURE.md` and `DOWNLOAD_AND_OPEN_IN_VSCODE.md` describing the data model and how to open the project, plus an export helper script `scripts/export_project_zip.sh` and a top-level `.gitignore` entry to ignore `exports/*.zip`. 
- Created an `exports/.gitkeep` placeholder so the `exports` directory is present in the repo. 

### Testing

- No automated tests were added or executed as part of this change. 
- Basic static checks and runtime builds were not run in CI for this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fabf2b14c832c889be5bbff4e68e3)